### PR TITLE
Add OwnerTeamID field to Alert

### DIFF
--- a/alert/result.go
+++ b/alert/result.go
@@ -27,6 +27,7 @@ type Alert struct {
 	Responders     []Responder `json:"responders"`
 	Integration    Integration `json:"integration,omitempty"`
 	Report         Report      `json:"report,omitempty"`
+	OwnerTeamID    string      `json:"ownerTeamId,omitempty"`
 }
 
 type Integration struct {


### PR DESCRIPTION
This field is omitted from the upstream repo, yet is supported by
Atlassian.

I raised
https://getsupport.atlassian.com/servicedesk/customer/portal/45/OGSP-74633
and they stated:
```
Thank you for your feedback about the Go and Python SDKs.

I will be asking the product teams to have a look at those sections too. The
API and the SDKs need to be in sync without any differences.

These are tracked internally by another ticket. The team will be adding this
to their backlogs and will be working on it.
```
Unfortunately it doesn't look like they will simply accept a PR, so we
will keep this fork for now.